### PR TITLE
Fix variable typos and update rogue part cleanup

### DIFF
--- a/Assets/Code/Base/Workshop.cs
+++ b/Assets/Code/Base/Workshop.cs
@@ -29,10 +29,10 @@ public class Workshop : MonoBehaviour
             workshopCollider.enabled = true;
         }
 
-        DestroyRougueParts();
+        DestroyRogueParts();
     }
 
-    void DestroyRougueParts()
+    void DestroyRogueParts()
     {
         Part[] allParts = FindObjectsOfType<Part>();
 
@@ -41,7 +41,7 @@ public class Workshop : MonoBehaviour
             if (part.transform.parent == null) // If it has no parent, destroy it
             {
                 Debug.Log($"Destroying orphaned part: {part.name}");
-                part.DestroyRougue();
+                part.DestroyRogue();
             }
         }
     }

--- a/Assets/Code/Parts/Part.cs
+++ b/Assets/Code/Parts/Part.cs
@@ -181,7 +181,7 @@ public class Part : MonoBehaviour
         return prefabID;
     }
 
-    public void DestroyRougue()
+    public void DestroyRogue()
     {
         PartCard partCard = FindPartCardByID(prefabID);
 

--- a/Assets/Code/Parts/PartData.cs
+++ b/Assets/Code/Parts/PartData.cs
@@ -9,7 +9,7 @@ public class PartData
     public string attachmentPointName;
 
     public bool isDeployed;
-    public bool isAtached;
+    public bool isAttached;
     public bool isActive;
 
     public Vector3 localPosition;
@@ -24,7 +24,7 @@ public class PartData
         partType = "";
         attachmentPointName = "";
         isDeployed = false;
-        isAtached = false;
+        isAttached = false;
         isActive = false;
         localPosition = Vector3.zero;
         localRotation = Quaternion.identity;

--- a/Assets/Code/UI/Cards/PartCard.cs
+++ b/Assets/Code/UI/Cards/PartCard.cs
@@ -21,7 +21,7 @@ public class PartCard : MonoBehaviour
 
     private void Start()
     {
-        if (partData.isDeployed && !partData.isAtached)
+        if (partData.isDeployed && !partData.isAttached)
         {
             partData.isDeployed = false;
             deployButton.interactable = true;
@@ -82,7 +82,7 @@ public class PartCard : MonoBehaviour
         Debug.Log("Point name: " + partData.attachmentPointName);
         Debug.Log("Part ID: " + partData.partID);
         Debug.Log("Part name: " + partData.partName);
-        Debug.Log("Attached?: " + partData.isAtached);
+        Debug.Log("Attached?: " + partData.isAttached);
     }
 
     void SetEnergyUsage(string partName)
@@ -114,13 +114,13 @@ public class PartCard : MonoBehaviour
 
     public void AttachToRobot(Transform point)
     {
-        partData.isAtached = true;
+        partData.isAttached = true;
         partData.attachmentPointName = point.name;
     }
 
     public void DetachFromRobot()
     {
-        partData.isAtached = false;
+        partData.isAttached = false;
         partData.attachmentPointName = "";
     }
 }


### PR DESCRIPTION
## Summary
- fix spelling of `isAttached` in `PartData` and update all usages
- rename `DestroyRougue` and `DestroyRougueParts` to `DestroyRogue` and `DestroyRogueParts`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840058b4cd4832c9007a5e05607e82e