### PR TITLE
Cache object references via serialized fields

### DIFF
--- a/Assets/Code/CameraManager.cs
+++ b/Assets/Code/CameraManager.cs
@@ -30,15 +30,15 @@ public class CameraManager : MonoBehaviour
         {
             if (Input.GetMouseButtonDown(0))
             {
-                dragOrigin = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+                dragOrigin = mainCamera.ScreenToWorldPoint(Input.mousePosition);
             }
 
             if (Input.GetMouseButton(0))
             {
-                Vector3 difference = dragOrigin - Camera.main.ScreenToWorldPoint(Input.mousePosition);
+                Vector3 difference = dragOrigin - mainCamera.ScreenToWorldPoint(Input.mousePosition);
                 mainCamera.transform.position += difference * dragSpeed;
 
-                dragOrigin = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+                dragOrigin = mainCamera.ScreenToWorldPoint(Input.mousePosition);
             }
         }
     }

--- a/Assets/Code/LevelManager.cs
+++ b/Assets/Code/LevelManager.cs
@@ -4,7 +4,7 @@ using UnityEngine.SceneManagement;
 public class LevelManager : MonoBehaviour
 {
     // Spawn robot
-    RobotManager robotManager;
+    [SerializeField] private RobotManager robotManager;
 
     [SerializeField] private Transform spawnPoint;
 
@@ -12,7 +12,10 @@ public class LevelManager : MonoBehaviour
     {
         if (SceneManager.GetActiveScene().name == "Level")
         {
-            robotManager = FindFirstObjectByType<RobotManager>();
+            if (robotManager == null)
+            {
+                robotManager = FindFirstObjectByType<RobotManager>();
+            }
 
             robotManager.SpawnRobot(spawnPoint);
             RobotCamera.FindRobot();

--- a/Assets/Code/Parts/Part.cs
+++ b/Assets/Code/Parts/Part.cs
@@ -11,14 +11,33 @@ public class Part : MonoBehaviour
     protected bool isDragging = false;
     private Vector3 offset;
 
-    InventoryManager inventoryManager;
-    RectTransform recycleIcon;
-    Core core;
+    [SerializeField] private InventoryManager inventoryManager;
+    [SerializeField] private RectTransform recycleIcon;
+    [SerializeField] private Core core;
+    [SerializeField] private Camera mainCamera;
 
-    public void Start()
+    private void Awake()
     {
-        inventoryManager = FindFirstObjectByType<InventoryManager>();
-        core = FindFirstObjectByType<Core>();
+        if (mainCamera == null)
+        {
+            mainCamera = Camera.main;
+        }
+        if (inventoryManager == null)
+        {
+            inventoryManager = FindFirstObjectByType<InventoryManager>();
+        }
+        if (core == null)
+        {
+            core = FindFirstObjectByType<Core>();
+        }
+        if (recycleIcon == null)
+        {
+            GameObject recycleObj = GameObject.Find("Recycle");
+            if (recycleObj != null)
+            {
+                recycleIcon = recycleObj.GetComponent<RectTransform>();
+            }
+        }
 
         CheckInitialAttachment();
     }
@@ -45,9 +64,11 @@ public class Part : MonoBehaviour
 
     private bool IsOverRecycle()
     {
-        recycleIcon = GameObject.Find("Recycle").GetComponent<RectTransform>();
-        if (recycleIcon == null) return false;
-        Vector2 screenPosition = Camera.main.WorldToScreenPoint(transform.position);
+        if (recycleIcon == null)
+        {
+            return false;
+        }
+        Vector2 screenPosition = mainCamera.WorldToScreenPoint(transform.position);
         return RectTransformUtility.RectangleContainsScreenPoint(recycleIcon, screenPosition);
     }
 
@@ -167,8 +188,8 @@ public class Part : MonoBehaviour
     private Vector3 GetMouseWorldPosition()
     {
         Vector3 mousePoint = Input.mousePosition;
-        mousePoint.z = Camera.main.WorldToScreenPoint(gameObject.transform.position).z;
-        return Camera.main.ScreenToWorldPoint(mousePoint);
+        mousePoint.z = mainCamera.WorldToScreenPoint(gameObject.transform.position).z;
+        return mainCamera.ScreenToWorldPoint(mousePoint);
     }
 
     public void SetPrefabID(string id)

--- a/Assets/Code/Parts/Wheel.cs
+++ b/Assets/Code/Parts/Wheel.cs
@@ -4,8 +4,9 @@ using static UnityEngine.EventSystems.EventTrigger;
 public class Wheel : Part
 {
     private Rigidbody2D rb2D;
-    private GameManager gameManager;
-    private ResourceManager resourceManager;
+    [SerializeField] private GameManager gameManager;
+    [SerializeField] private ResourceManager resourceManager;
+    [SerializeField] private Core core;
 
     private float rotationSpeedEco = 1.2f;
     private float rotationSpeedNormal = 1.6f;
@@ -13,8 +14,18 @@ public class Wheel : Part
 
     private void Awake()
     {
-        gameManager = FindFirstObjectByType<GameManager>();
-        resourceManager = FindFirstObjectByType<ResourceManager>();
+        if (gameManager == null)
+        {
+            gameManager = FindFirstObjectByType<GameManager>();
+        }
+        if (resourceManager == null)
+        {
+            resourceManager = FindFirstObjectByType<ResourceManager>();
+        }
+        if (core == null)
+        {
+            core = FindFirstObjectByType<Core>();
+        }
     }
 
     private new void Start()
@@ -47,7 +58,10 @@ public class Wheel : Part
             // Eliminate constraints
             rb2D.constraints = RigidbodyConstraints2D.None;
 
-            Core core = FindFirstObjectByType<Core>();
+            if (core == null)
+            {
+                core = FindFirstObjectByType<Core>();
+            }
             if (core != null)
             {
                 Rigidbody2D coreRb2D = core.GetComponent<Rigidbody2D>();

--- a/Assets/Code/ResourceManager.cs
+++ b/Assets/Code/ResourceManager.cs
@@ -4,12 +4,12 @@ using UnityEngine;
 public class ResourceManager : MonoBehaviour
 {
     private int scrap;
-    private TMP_Text scrapCounter;
+    [SerializeField] private TMP_Text scrapCounter;
 
     private float energy;
     private int energyCap = 800;
     private int energyGain = 40;
-    private TMP_Text energyCounter;
+    [SerializeField] private TMP_Text energyCounter;
 
     public float Energy
     {
@@ -58,8 +58,22 @@ public class ResourceManager : MonoBehaviour
 
     private void Start()
     {
-        scrapCounter = GameObject.Find("Scrap counter").GetComponent<TMP_Text>();
-        energyCounter = GameObject.Find("Energy counter").GetComponent<TMP_Text>();
+        if (scrapCounter == null)
+        {
+            GameObject scrapObj = GameObject.Find("Scrap counter");
+            if (scrapObj != null)
+            {
+                scrapCounter = scrapObj.GetComponent<TMP_Text>();
+            }
+        }
+        if (energyCounter == null)
+        {
+            GameObject energyObj = GameObject.Find("Energy counter");
+            if (energyObj != null)
+            {
+                energyCounter = energyObj.GetComponent<TMP_Text>();
+            }
+        }
         LoadScrap();
         LoadEnergy();
     }

--- a/Assets/Code/RobotCamera.cs
+++ b/Assets/Code/RobotCamera.cs
@@ -3,10 +3,21 @@ using UnityEngine;
 public class RobotCamera : MonoBehaviour
 {
     static private Transform target;
+    [SerializeField] private Transform initialTarget;
 
     private void Awake()
     {
-        FindRobot();
+        if (target == null)
+        {
+            if (initialTarget != null)
+            {
+                target = initialTarget;
+            }
+            else
+            {
+                FindRobot();
+            }
+        }
     }
 
     private void Update()
@@ -31,5 +42,10 @@ public class RobotCamera : MonoBehaviour
         {
             target = coreObject.transform;
         }
+    }
+
+    public static void SetTarget(Transform newTarget)
+    {
+        target = newTarget;
     }
 }

--- a/Assets/Code/UI/Cards/PartCard.cs
+++ b/Assets/Code/UI/Cards/PartCard.cs
@@ -17,7 +17,7 @@ public class PartCard : MonoBehaviour
     string cardID;
 
     PartData partData;
-    Workshop workshop;
+    [SerializeField] private Workshop workshop;
 
     private void Start()
     {
@@ -27,7 +27,10 @@ public class PartCard : MonoBehaviour
             deployButton.interactable = true;
         }
 
-        workshop = FindFirstObjectByType<Workshop>();
+        if (workshop == null)
+        {
+            workshop = FindFirstObjectByType<Workshop>();
+        }
 
         modifyButton.onClick.AddListener(ModifyDeployedPart);
     }

--- a/Assets/Code/UI/Cards/ShopCard.cs
+++ b/Assets/Code/UI/Cards/ShopCard.cs
@@ -13,11 +13,14 @@ public class ShopCard : MonoBehaviour
     [SerializeField] InventoryManager inventory;
     [SerializeField] GameObject buyBtn;
 
-    ResourceManager resourceManager;
+    [SerializeField] private ResourceManager resourceManager;
 
     private void Start()
     {
-        resourceManager = FindFirstObjectByType<ResourceManager>();
+        if (resourceManager == null)
+        {
+            resourceManager = FindFirstObjectByType<ResourceManager>();
+        }
     }
 
     public void BuyPart(string partName)


### PR DESCRIPTION
## Summary
- cache frequently used references in `Part`, `Wheel`, `ResourceManager`, `RobotCamera`, and other scripts
- expose references in the inspector and populate them during `Awake`/`Start`
- use cached camera in `CameraManager`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68400925e890832cb06089bb7b569c10